### PR TITLE
Add self-hosted client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ```console
 > pip install pydantic
 > pip install requests
+> pip install httpx
 ```
 
 Если вы устанавливаете из PyPI, то эти библиотеки устанавливаются автоматически:
@@ -25,11 +26,19 @@
 
 1. Название моделей полностью копируют URL этой модели на официальном API.
 2. У всех моделей есть описания параметров, краткого описания из официального API и ссылка на запрос.
-3. Названия параметров модели и их типизация идентичны параметрам из официального API (За исключением параметра ```token```)
+3. Названия параметров модели и их типизация идентичны параметрам из официального API (За исключением параметра `token`)
 
 ## Возможности
 
-Вы можете использовать токен не только к отдельным моделям, но и к самой функции запроса:
+Токен можно передавать тремя способами:
+
+1. в саму модель
+2. в `yougile.query(...)` / `yougile.query_async(...)`
+3. в `yougile.Client(...)` / `yougile.AsyncClient(...)`
+
+Приоритет такой: явный аргумент функции/метода, затем токен клиента, затем токен модели.
+
+Пример передачи токена в функцию запроса:
 
 ```python
 import requests
@@ -37,13 +46,13 @@ import yougile
 import yougile.models as models
 
 def yougile_get(model: yougile.BaseModel) -> requests.Response:
-    return yougile.query(model,token="TOKEN")
+    return yougile.query(model, token="TOKEN")
 
 model = models.ChatMessageController_search(chatId="12324")
 response = yougile_get(model)
 
-for msg in response.json()['content']:
-    print(msg['text'])
+for msg in response.json()["content"]:
+    print(msg["text"])
 
 ```
 
@@ -52,12 +61,15 @@ for msg in response.json()['content']:
 ### 1. Получаем список доступных компаний
 
 ```python
-import yougile # Импортируем библиотеку
-import yougile.models as models # Импортируем модели
+import yougile  # Импортируем библиотеку
+import yougile.models as models  # Импортируем модели
 
-model = models.AuthKeyController_companiesList(login="USERNAME",password="PASSWORD") # Указываем модель запроса листа компаний через авторизацию
-response = yougile.query(model) # Делаем запрос на сервер
-print(response.text) # Получаем ответ
+model = models.AuthKeyController_companiesList(
+    login="USERNAME",
+    password="PASSWORD",
+)  # Указываем модель запроса листа компаний через авторизацию
+response = yougile.query(model)  # Делаем запрос на сервер
+print(response.text)  # Получаем ответ
 ```
 
 ### 2. Создаем токен
@@ -66,9 +78,13 @@ print(response.text) # Получаем ответ
 import yougile
 import yougile.models as models
 
-model = models.AuthKeyController_create(login="USERNAME",password="PASSWORD",companyId="12345")
+model = models.AuthKeyController_create(
+    login="USERNAME",
+    password="PASSWORD",
+    companyId="12345",
+)
 response = yougile.query(model)
-print(response.json()['key'])
+print(response.json()["key"])
 ```
 
 ### 3. Получаем историю сообщений
@@ -77,10 +93,10 @@ print(response.json()['key'])
 import yougile
 import yougile.models as models
 
-model = models.ChatMessageController_search(token="TOKEN",chatId="12324")
+model = models.ChatMessageController_search(token="TOKEN", chatId="12324")
 response = yougile.query(model)
-for msg in response.json()['content']:
-    print(msg['text'])
+for msg in response.json()["content"]:
+    print(msg["text"])
 ```
 
 ### 4. Асинхронный запрос: Загружаем файл
@@ -102,7 +118,67 @@ asyncio.run(main())
 
 ```
 
+### 5. Self-hosted: указываем `base_url`
+
+```python
+import yougile
+import yougile.models as models
+
+model = models.ChatMessageController_search(token="TOKEN", chatId="12324")
+response = yougile.query(
+    model,
+    base_url="https://yougile.example.com",
+)
+
+for msg in response.json()["content"]:
+    print(msg["text"])
+```
+
+### 6. Клиент с настройками подключения
+
+```python
+import yougile
+import yougile.models as models
+
+client = yougile.Client(
+    base_url="https://yougile.example.com",
+    token="TOKEN",
+)
+
+model = models.ChatMessageController_search(chatId="12324")
+response = client.query(model)
+
+for msg in response.json()["content"]:
+    print(msg["text"])
+```
+
+### 7. Асинхронный клиент с настройками подключения
+
+```python
+import asyncio
+import yougile
+import yougile.models as models
+
+async def main():
+    client = yougile.AsyncClient(
+        base_url="https://yougile.example.com",
+        token="TOKEN",
+    )
+    model = models.ChatMessageController_search(chatId="12324")
+    response = await client.query(model)
+    print(response.json())
+
+asyncio.run(main())
+```
+
 ## Версии
+
+### v1.4.0
+
+* Добавлена поддержка self-hosted YouGile через параметр `base_url` в `query` и `query_async`
+* Добавлены `yougile.Client` и `yougile.AsyncClient` для хранения настроек подключения
+* Параметр `token` в API-моделях сделан необязательным: токен теперь можно хранить только в клиенте или передавать в функцию запроса
+* Обновлена документация и примеры использования
 
 ### v1.3.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yougile-api"
-version = "1.3.0"
+version = "1.4.0"
 authors = [
   { name="txello", email="txello7@proton.me" },
 ]

--- a/yougile/__init__.py
+++ b/yougile/__init__.py
@@ -1,4 +1,6 @@
-from .request import query, BaseModel
-from .async_request import query_async
+from pydantic import BaseModel
 
-__all__ = ["query", "query_async", "BaseModel"]
+from .async_request import AsyncClient, query_async
+from .request import Client, query
+
+__all__ = ["AsyncClient", "BaseModel", "Client", "query", "query_async"]

--- a/yougile/async_request.py
+++ b/yougile/async_request.py
@@ -3,6 +3,7 @@ from io import IOBase
 import os
 from pathlib import Path
 from typing import Any
+
 import httpx
 from pydantic import BaseModel
 
@@ -10,92 +11,108 @@ from pydantic import BaseModel
 YOUGILE_URL = "https://ru.yougile.com"
 
 
-async def query_async(arg: BaseModel, token: str | None = None) -> httpx.Response:
-    """
-    Универсальный запрос:
-    - если модель содержит _file (имена полей-файлов) -> multipart/form-data (files=..., data=...)
-    - иначе -> JSON (json=...)
-    Поддерживаются варианты значений файлового поля:
-      bytes | путь (str/Path) | файловый объект (IOBase) | ('name', bytes[, 'mime/type'])
-    """
-    arg = arg.model_copy()
-    url: str = getattr(arg, "_url")
-    method: str = getattr(arg, "_method", "get").lower()
+def _normalize_base_url(base_url: str) -> str:
+    return base_url.rstrip("/")
 
-    # --- Заголовки ---
-    headers: dict[str, str] = {}
 
-    # Авторизация
-    if hasattr(arg, "token"):
-        headers["Authorization"] = f"Bearer {token or getattr(arg, 'token')}"
-        if token is None:
+class AsyncClient:
+    """Асинхронный клиент YouGile API с настройками подключения."""
+
+    def __init__(self, token: str | None = None, base_url: str = YOUGILE_URL) -> None:
+        self.token = token
+        self.base_url = _normalize_base_url(base_url)
+
+    async def query(self, arg: BaseModel, token: str | None = None) -> httpx.Response:
+        """
+        Универсальный запрос:
+        - если модель содержит _file (имена полей-файлов) -> multipart/form-data
+        - иначе -> JSON
+        Поддерживаются варианты значений файлового поля:
+          bytes | путь (str/Path) | файловый объект (IOBase) | ('name', bytes[, 'mime/type'])
+        """
+        arg = arg.model_copy()
+        url: str = getattr(arg, "_url")
+        method: str = getattr(arg, "_method", "get").lower()
+
+        headers: dict[str, str] = {}
+        request_token = token or self.token
+
+        if hasattr(arg, "token"):
+            model_token = getattr(arg, "token")
+            if request_token is None:
+                request_token = model_token
+            if request_token is not None:
+                headers["Authorization"] = f"Bearer {request_token}"
             delattr(arg, "token")
 
-    # --- Path-параметры ---
-    for name in getattr(arg, "_url_parse", ()):
-        url = url.format(**{name: getattr(arg, name)})
-        delattr(arg, name)
+        for name in getattr(arg, "_url_parse", ()):
+            url = url.format(**{name: getattr(arg, name)})
+            delattr(arg, name)
 
-    # --- Query-параметры ---
-    params_parts: list[str] = []
-    for name in getattr(arg, "_url_params", ()):
-        value = getattr(arg, name)
-        if value is not None:
-            params_parts.append(f"{name}={value}")
-        delattr(arg, name)
-    if params_parts:
-        url = f"{url}?{'&'.join(params_parts)}"
+        params_parts: list[str] = []
+        for name in getattr(arg, "_url_params", ()):
+            value = getattr(arg, name)
+            if value is not None:
+                params_parts.append(f"{name}={value}")
+            delattr(arg, name)
+        if params_parts:
+            url = f"{url}?{'&'.join(params_parts)}"
 
-    # --- Тело ---
-    body: dict[str, Any] = arg.model_dump(exclude_none=True)
+        body: dict[str, Any] = arg.model_dump(exclude_none=True)
+        file_field_names = tuple(getattr(arg, "_file", ()))
 
-    # --- Файлы / multipart ---
-    file_field_names = tuple(getattr(arg, "_file", ()))
-    if file_field_names:
-        # В multipart Content-Type выставляет requests -> не задаём его в headers
-        with ExitStack() as stack:
-            files: dict[str, Any] = {}
-            for fname in file_field_names:
-                v = body.pop(fname, None)
-                if v is None:
-                    continue
+        if file_field_names:
+            with ExitStack() as stack:
+                files: dict[str, Any] = {}
+                for fname in file_field_names:
+                    value = body.pop(fname, None)
+                    if value is None:
+                        continue
 
-                # ('name.ext', bytes[, 'mime/type'])
-                if isinstance(v, tuple) and 2 <= len(v) <= 3 and isinstance(v[0], str):
-                    files[fname] = v
-                    continue
+                    if (
+                        isinstance(value, tuple)
+                        and 2 <= len(value) <= 3
+                        and isinstance(value[0], str)
+                    ):
+                        files[fname] = value
+                        continue
 
-                # bytes
-                if isinstance(v, (bytes, bytearray)):
-                    files[fname] = (f"{fname}.bin", bytes(v))
-                    continue
+                    if isinstance(value, (bytes, bytearray)):
+                        files[fname] = (f"{fname}.bin", bytes(value))
+                        continue
 
-                # файловый объект
-                if isinstance(v, IOBase):
-                    name = getattr(v, "name", f"{fname}.bin")
-                    files[fname] = (os.path.basename(str(name)), v)
-                    continue
+                    if isinstance(value, IOBase):
+                        name = getattr(value, "name", f"{fname}.bin")
+                        files[fname] = (os.path.basename(str(name)), value)
+                        continue
 
-                # путь (str/Path/os.PathLike)
-                p = Path(str(v))
-                fobj = stack.enter_context(open(p, "rb"))
-                files[fname] = (p.name, fobj)
+                    path = Path(str(value))
+                    file_object = stack.enter_context(open(path, "rb"))
+                    files[fname] = (path.name, file_object)
 
-            async with httpx.AsyncClient() as client:
-                return await client.request(
-                    method=method,
-                    url=YOUGILE_URL + url,
-                    headers=headers,
-                    data=body or None,
-                    files=files,
-                )
+                async with httpx.AsyncClient() as client:
+                    return await client.request(
+                        method=method,
+                        url=self.base_url + url,
+                        headers=headers,
+                        data=body or None,
+                        files=files,
+                    )
 
-    # --- JSON ---
-    headers["Content-Type"] = "application/json"
-    async with httpx.AsyncClient() as client:
-        return await client.request(
-            method=method,
-            url=YOUGILE_URL + url,
-            headers=headers,
-            json=body or None,
-        )
+        headers["Content-Type"] = "application/json"
+        async with httpx.AsyncClient() as client:
+            return await client.request(
+                method=method,
+                url=self.base_url + url,
+                headers=headers,
+                json=body or None,
+            )
+
+
+async def query_async(
+    arg: BaseModel,
+    token: str | None = None,
+    base_url: str = YOUGILE_URL,
+) -> httpx.Response:
+    """Выполнить асинхронный запрос к YouGile API."""
+    return await AsyncClient(token=token, base_url=base_url).query(arg)

--- a/yougile/models/boards.py
+++ b/yougile/models/boards.py
@@ -19,7 +19,7 @@ class BoardController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/boards"
-    token: str
+    token: str | None = None
     _url_params: tuple = ("includeDeleted", "limit", "offset", "projectId", "title")
 
     includeDeleted: bool | None = None
@@ -45,7 +45,7 @@ class BoardController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/boards"
-    token: str
+    token: str | None = None
 
     title: str
     projectId: str
@@ -66,7 +66,7 @@ class BoardController_get(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/boards/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -90,7 +90,7 @@ class BoardController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/boards/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str

--- a/yougile/models/chatmessages.py
+++ b/yougile/models/chatmessages.py
@@ -23,7 +23,7 @@ class ChatMessageController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/chats/{chatId}/messages"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("chatId",)
     _url_params: tuple = (
         "fromUserId",
@@ -64,7 +64,7 @@ class ChatMessageController_sendMessage(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/chats/{chatId}/messages"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("chatId",)
 
     chatId: str
@@ -88,7 +88,7 @@ class ChatMessageController_get(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/chats/{chatId}/messages/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("chatId", "id")
     chatId: str
     id: str
@@ -112,7 +112,7 @@ class ChatMessageController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/chats/{chatId}/messages/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("chatId", "id")
 
     chatId: str

--- a/yougile/models/columns.py
+++ b/yougile/models/columns.py
@@ -19,7 +19,7 @@ class ColumnController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/columns"
-    token: str
+    token: str | None = None
     _url_params: tuple = ("boardId", "includeDeleted", "limit", "offset", "title")
 
     boardId: str | None = None
@@ -45,7 +45,7 @@ class ColumnController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/columns"
-    token: str
+    token: str | None = None
 
     title: str | None = None
     color: int | None = None
@@ -66,7 +66,7 @@ class ColumnController_get(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/columns/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -90,7 +90,7 @@ class ColumnController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/columns/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str

--- a/yougile/models/companies.py
+++ b/yougile/models/companies.py
@@ -13,7 +13,7 @@ class CompanyController_get(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/companies*"
-    token: str
+    token: str | None = None
 
 
 class CompanyController_update(BaseModel):
@@ -33,7 +33,7 @@ class CompanyController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/companies*"
-    token: str
+    token: str | None = None
 
     deleted: bool | None = None
     title: str | None = None

--- a/yougile/models/departments.py
+++ b/yougile/models/departments.py
@@ -19,7 +19,7 @@ class DepartmentController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/departments"
-    token: str
+    token: str | None = None
     _url_params: tuple = ("includeDeleted", "limit", "offset", "title")
 
     includeDeleted: bool | None = None
@@ -45,7 +45,7 @@ class DepartmentController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/departments"
-    token: str
+    token: str | None = None
 
     title: str | None = None
     parentId: str | None = None
@@ -66,7 +66,7 @@ class DepartmentController_get(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/departments/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -90,7 +90,7 @@ class DepartmentController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/departments/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str

--- a/yougile/models/employees.py
+++ b/yougile/models/employees.py
@@ -17,7 +17,7 @@ class UserController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/users"
-    token: str
+    token: str | None = None
     _url_params: tuple = ("email", "limit", "offset", "projectId")
 
     email: str | None = None
@@ -40,7 +40,7 @@ class UserController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/users"
-    token: str
+    token: str | None = None
 
     email: str
     isAdmin: bool | None = None
@@ -59,7 +59,7 @@ class UserController_get(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/users/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -79,7 +79,7 @@ class UserController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/users/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -99,7 +99,7 @@ class UserController_delete(BaseModel):
 
     _method: str = "delete"
     _url: str = "/api-v2/users/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str

--- a/yougile/models/files.py
+++ b/yougile/models/files.py
@@ -18,7 +18,7 @@ class FileController_uploadFile(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/upload-file"
-    token: str
+    token: str | None = None
     _file: tuple = ("file",)
 
     file: str

--- a/yougile/models/groupchats.py
+++ b/yougile/models/groupchats.py
@@ -18,7 +18,7 @@ class GroupChatController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/group-chats"
-    token: str
+    token: str | None = None
     _url_params: tuple = ("includeDeleted", "limit", "offset", "title")
 
     includeDeleted: bool | None = None
@@ -42,7 +42,7 @@ class GroupChatController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/group-chats"
-    token: str
+    token: str | None = None
 
     title: str
     users: dict
@@ -62,7 +62,7 @@ class GroupChatController_get(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/group-chats/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -85,7 +85,7 @@ class GroupChatController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/group-chats/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str

--- a/yougile/models/projectroles.py
+++ b/yougile/models/projectroles.py
@@ -18,7 +18,7 @@ class ProjectRolesController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/projects/{projectId}/roles"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("projectId",)
     _url_params: tuple = ("limit", "name", "offset")
 
@@ -45,7 +45,7 @@ class ProjectRolesController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/projects/{projectId}/roles"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("projectId",)
 
     projectId: str
@@ -69,7 +69,7 @@ class ProjectRolesController_get(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/projects/{projectId}/roles/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("projectId", "id")
 
     id: str
@@ -94,7 +94,7 @@ class ProjectRolesController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/projects/{projectId}/roles/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("projectId", "id")
 
     id: str
@@ -119,7 +119,7 @@ class ProjectRolesController_delete(BaseModel):
 
     _method: str = "delete"
     _url: str = "/api-v2/projects/{projectId}/roles/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("projectId", "id")
 
     id: str

--- a/yougile/models/projects.py
+++ b/yougile/models/projects.py
@@ -18,7 +18,7 @@ class ProjectController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/projects"
-    token: str
+    token: str | None = None
     _url_params: tuple = ("includeDeleted", "limit", "offset", "title")
 
     includeDeleted: bool | None = None
@@ -42,7 +42,7 @@ class ProjectController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/projects"
-    token: str
+    token: str | None = None
 
     title: str
     users: dict | None = None
@@ -62,7 +62,7 @@ class ProjectController_get(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/projects/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -85,7 +85,7 @@ class ProjectController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/projects/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str

--- a/yougile/models/sprintsticker.py
+++ b/yougile/models/sprintsticker.py
@@ -19,7 +19,7 @@ class SprintStickerController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/sprint-stickers"
-    token: str
+    token: str | None = None
     _url_params: tuple = ("boardId", "includeDeleted", "limit", "name", "offset")
 
     boardId: str | None = None
@@ -44,7 +44,7 @@ class SprintStickerController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/sprint-stickers"
-    token: str
+    token: str | None = None
 
     name: str
     states: list
@@ -64,7 +64,7 @@ class SprintStickerController_getSticker(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/sprint-stickers/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -86,7 +86,7 @@ class SprintStickerController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/sprint-stickers/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str

--- a/yougile/models/sprintstickerstate.py
+++ b/yougile/models/sprintstickerstate.py
@@ -18,7 +18,7 @@ class SprintStickerStateController_get(BaseModel):
     _method: str = "get"
     _url: str = "/api-v2/sprint-stickers/{stickerId}/states/{stickerStateId}"
     _url_parse: tuple = ("stickerId", "stickerStateId")
-    token: str
+    token: str | None = None
     _url_params: tuple = ("includeDeleted",)
 
     stickerId: str
@@ -46,7 +46,7 @@ class SprintStickerStateController_update(BaseModel):
     _method: str = "put"
     _url: str = "/api-v2/sprint-stickers/{stickerId}/states/{stickerStateId}"
     _url_parse: tuple = ("stickerId", "stickerStateId")
-    token: str
+    token: str | None = None
 
     stickerId: str
     stickerStateId: str
@@ -73,7 +73,7 @@ class SprintStickerStateController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/sprint-stickers/{stickerId}/states"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("stickerId",)
 
     stickerId: str

--- a/yougile/models/stringsticker.py
+++ b/yougile/models/stringsticker.py
@@ -19,7 +19,7 @@ class StringStickerController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/string-stickers"
-    token: str
+    token: str | None = None
     _url_params: tuple = ("boardId", "includeDeleted", "limit", "name", "offset")
 
     boardId: str | None = None
@@ -45,7 +45,7 @@ class StringStickerController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/string-stickers"
-    token: str
+    token: str | None = None
 
     name: str
     icon: str | None = None
@@ -66,7 +66,7 @@ class StringStickerController_get(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/string-stickers/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -89,7 +89,7 @@ class StringStickerController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/string-stickers/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str

--- a/yougile/models/stringstickerstate.py
+++ b/yougile/models/stringstickerstate.py
@@ -18,7 +18,7 @@ class StringStickerStateController_get(BaseModel):
     _method: str = "get"
     _url: str = "/api-v2/string-stickers/{stickerId}/states/{stickerStateId}"
     _url_parse: tuple = ("stickerId", "stickerStateId")
-    token: str
+    token: str | None = None
     _url_params: tuple = ("includeDeleted",)
 
     stickerId: str
@@ -45,7 +45,7 @@ class StringStickerStateController_update(BaseModel):
     _method: str = "put"
     _url: str = "/api-v2/string-stickers/{stickerId}/states/{stickerStateId}"
     _url_parse: tuple = ("stickerId", "stickerStateId")
-    token: str
+    token: str | None = None
 
     stickerId: str
     stickerStateId: str
@@ -70,7 +70,7 @@ class StringStickerStateController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/string-stickers/{stickerId}/states"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("stickerId",)
 
     stickerId: str

--- a/yougile/models/tasks.py
+++ b/yougile/models/tasks.py
@@ -20,7 +20,7 @@ class TaskController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/tasks"
-    token: str
+    token: str | None = None
     _url_params: tuple = (
         "assignedTo",
         "columnId",
@@ -59,7 +59,7 @@ class TaskController_searchReversed(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/tasks"
-    token: str
+    token: str | None = None
     _url_params: tuple = (
         "assignedTo",
         "columnId",
@@ -106,7 +106,7 @@ class TaskController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/tasks"
-    token: str
+    token: str | None = None
 
     title: str
     columnId: str | None = None
@@ -140,7 +140,7 @@ class TaskController_get(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/tasks/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -177,7 +177,7 @@ class TaskController_update(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/tasks/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -214,7 +214,7 @@ class TaskController_getChatSubscribers(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/tasks/{id}/chat-subscribers"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str
@@ -235,7 +235,7 @@ class TaskController_updateChatSubscribers(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/tasks/{id}/chat-subscribers"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str

--- a/yougile/models/webhooks.py
+++ b/yougile/models/webhooks.py
@@ -16,7 +16,7 @@ class WebhookController_create(BaseModel):
 
     _method: str = "post"
     _url: str = "/api-v2/webhooks"
-    token: str
+    token: str | None = None
 
     url: str
     event: str
@@ -36,7 +36,7 @@ class WebhookController_search(BaseModel):
 
     _method: str = "get"
     _url: str = "/api-v2/webhooks"
-    token: str
+    token: str | None = None
     _url_params: tuple = ("includeDeleted",)
 
     includeDeleted: bool | None = None
@@ -60,7 +60,7 @@ class WebhookController_put(BaseModel):
 
     _method: str = "put"
     _url: str = "/api-v2/webhooks/{id}"
-    token: str
+    token: str | None = None
     _url_parse: tuple = ("id",)
 
     id: str

--- a/yougile/request.py
+++ b/yougile/request.py
@@ -3,6 +3,7 @@ from io import IOBase
 import os
 from pathlib import Path
 from typing import Any
+
 import requests
 from pydantic import BaseModel
 
@@ -10,88 +11,104 @@ from pydantic import BaseModel
 YOUGILE_URL = "https://ru.yougile.com"
 
 
-def query(arg: BaseModel, token: str | None = None) -> requests.Response:
-    """
-    Универсальный запрос:
-    - если модель содержит _file (имена полей-файлов) -> multipart/form-data (files=..., data=...)
-    - иначе -> JSON (json=...)
-    Поддерживаются варианты значений файлового поля:
-      bytes | путь (str/Path) | файловый объект (IOBase) | ('name', bytes[, 'mime/type'])
-    """
-    arg = arg.model_copy()
-    url: str = getattr(arg, "_url")
-    method: str = getattr(arg, "_method", "get").lower()
+def _normalize_base_url(base_url: str) -> str:
+    return base_url.rstrip("/")
 
-    # --- Заголовки ---
-    headers: dict[str, str] = {}
 
-    # Авторизация
-    if hasattr(arg, "token"):
-        headers["Authorization"] = f"Bearer {token or getattr(arg, 'token')}"
-        if token is None:
+class Client:
+    """Клиент YouGile API с настройками подключения."""
+
+    def __init__(self, token: str | None = None, base_url: str = YOUGILE_URL) -> None:
+        self.token = token
+        self.base_url = _normalize_base_url(base_url)
+
+    def query(self, arg: BaseModel, token: str | None = None) -> requests.Response:
+        """
+        Универсальный запрос:
+        - если модель содержит _file (имена полей-файлов) -> multipart/form-data
+        - иначе -> JSON
+        Поддерживаются варианты значений файлового поля:
+          bytes | путь (str/Path) | файловый объект (IOBase) | ('name', bytes[, 'mime/type'])
+        """
+        arg = arg.model_copy()
+        url: str = getattr(arg, "_url")
+        method: str = getattr(arg, "_method", "get").lower()
+
+        headers: dict[str, str] = {}
+        request_token = token or self.token
+
+        if hasattr(arg, "token"):
+            model_token = getattr(arg, "token")
+            if request_token is None:
+                request_token = model_token
+            if request_token is not None:
+                headers["Authorization"] = f"Bearer {request_token}"
             delattr(arg, "token")
 
-    # --- Path-параметры ---
-    for name in getattr(arg, "_url_parse", ()):
-        url = url.format(**{name: getattr(arg, name)})
-        delattr(arg, name)
+        for name in getattr(arg, "_url_parse", ()):
+            url = url.format(**{name: getattr(arg, name)})
+            delattr(arg, name)
 
-    # --- Query-параметры ---
-    params_parts: list[str] = []
-    for name in getattr(arg, "_url_params", ()):
-        value = getattr(arg, name)
-        if value is not None:
-            params_parts.append(f"{name}={value}")
-        delattr(arg, name)
-    if params_parts:
-        url = f"{url}?{'&'.join(params_parts)}"
+        params_parts: list[str] = []
+        for name in getattr(arg, "_url_params", ()):
+            value = getattr(arg, name)
+            if value is not None:
+                params_parts.append(f"{name}={value}")
+            delattr(arg, name)
+        if params_parts:
+            url = f"{url}?{'&'.join(params_parts)}"
 
-    # --- Тело ---
-    body: dict[str, Any] = arg.model_dump(exclude_none=True)
+        body: dict[str, Any] = arg.model_dump(exclude_none=True)
+        file_field_names = tuple(getattr(arg, "_file", ()))
 
-    # --- Файлы / multipart ---
-    file_field_names = tuple(getattr(arg, "_file", ()))
-    if file_field_names:
-        # В multipart Content-Type выставляет requests -> не задаём его в headers
-        with ExitStack() as stack:
-            files: dict[str, Any] = {}
-            for fname in file_field_names:
-                v = body.pop(fname, None)
-                if v is None:
-                    continue
+        if file_field_names:
+            with ExitStack() as stack:
+                files: dict[str, Any] = {}
+                for fname in file_field_names:
+                    value = body.pop(fname, None)
+                    if value is None:
+                        continue
 
-                # ('name.ext', bytes[, 'mime/type'])
-                if isinstance(v, tuple) and 2 <= len(v) <= 3 and isinstance(v[0], str):
-                    files[fname] = v
-                    continue
+                    if (
+                        isinstance(value, tuple)
+                        and 2 <= len(value) <= 3
+                        and isinstance(value[0], str)
+                    ):
+                        files[fname] = value
+                        continue
 
-                # bytes
-                if isinstance(v, (bytes, bytearray)):
-                    files[fname] = (f"{fname}.bin", bytes(v))
-                    continue
+                    if isinstance(value, (bytes, bytearray)):
+                        files[fname] = (f"{fname}.bin", bytes(value))
+                        continue
 
-                # файловый объект
-                if isinstance(v, IOBase):
-                    name = getattr(v, "name", f"{fname}.bin")
-                    files[fname] = (os.path.basename(str(name)), v)
-                    continue
+                    if isinstance(value, IOBase):
+                        name = getattr(value, "name", f"{fname}.bin")
+                        files[fname] = (os.path.basename(str(name)), value)
+                        continue
 
-                # путь (str/Path/os.PathLike)
-                p = Path(str(v))
-                fobj = stack.enter_context(open(p, "rb"))
-                files[fname] = (p.name, fobj)
+                    path = Path(str(value))
+                    file_object = stack.enter_context(open(path, "rb"))
+                    files[fname] = (path.name, file_object)
 
-            return getattr(requests, method)(
-                url=YOUGILE_URL + url,
-                headers=headers,
-                data=body or None,
-                files=files,
-            )
+                return getattr(requests, method)(
+                    url=self.base_url + url,
+                    headers=headers,
+                    data=body or None,
+                    files=files,
+                )
 
-    # --- JSON ---
-    headers["Content-Type"] = "application/json"
-    return getattr(requests, method)(
-        url=YOUGILE_URL + url,
-        headers=headers,
-        json=body or None,
-    )
+        headers["Content-Type"] = "application/json"
+        return getattr(requests, method)(
+            url=self.base_url + url,
+            headers=headers,
+            json=body or None,
+        )
+
+
+def query(
+    arg: BaseModel,
+    token: str | None = None,
+    base_url: str = YOUGILE_URL,
+) -> requests.Response:
+    """Выполнить синхронный запрос к YouGile API."""
+    return Client(token=token, base_url=base_url).query(arg)


### PR DESCRIPTION
Closes #11

## Что сделано

Этот PR добавляет поддержку self-hosted инсталляций YouGile без поломки обратной совместимости с текущим API библиотеки.

Добавлено:
- `base_url` в `yougile.query(...)`
- `base_url` в `yougile.query_async(...)`
- `yougile.Client`
- `yougile.AsyncClient`

Также `token` в API-моделях сделан необязательным, поэтому теперь доступны оба сценария:
- старый: передавать `token` прямо в модель
- новый: хранить `token` и `base_url` в клиенте

## Примеры

Через функцию запроса:

```python
response = yougile.query(
    model,
    base_url="https://yougile.example.com",
)
```

Через клиент:

```python
client = yougile.Client(
    base_url="https://yougile.example.com",
    token="TOKEN",
)

response = client.query(model)
```

Асинхронный вариант:

```python
client = yougile.AsyncClient(
    base_url="https://yougile.example.com",
    token="TOKEN",
)

response = await client.query(model)
```

## Обратная совместимость

Существующий код продолжает работать:
- если `token` передается в модель, поведение остается прежним
- если `token` передается в `query(...)` / `query_async(...)`, он по-прежнему используется

Приоритет токена теперь такой:
1. явный аргумент функции/метода
2. токен клиента
3. токен модели

## Дополнительно

- обновлен `README` с новыми примерами использования
- версия библиотеки повышена до `1.4.0`

