### PR TITLE
Improve request layer and add quality checks

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,38 @@
+name: Quality
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  push:
+    branches:
+      - dev
+      - main
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Ruff
+        run: ruff check .
+
+      - name: Pyright
+        run: pyright
+
+      - name: Pytest
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ venv/
 *.pyo
 *.pyd
 .ruff_cache/
+.pytest_cache/
+.coverage
+htmlcov/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ## Установка
 
+Поддерживаемая версия Python: `3.10+`
+
 Если вы устанавливаете вручную, перед использованием библиотеки, необходимо установить следующее:
 
 ```console
@@ -169,6 +171,38 @@ async def main():
     print(response.json())
 
 asyncio.run(main())
+```
+
+### 8. Клиент с timeout
+
+```python
+import yougile
+import yougile.models as models
+
+client = yougile.Client(
+    token="TOKEN",
+    timeout=10.0,
+)
+
+model = models.ChatMessageController_search(chatId="12324")
+response = client.query(model)
+print(response.status_code)
+```
+
+## Разработка
+
+Установка dev-зависимостей:
+
+```console
+> pip install -e ".[dev]"
+```
+
+Локальные проверки:
+
+```console
+> ruff check .
+> pyright
+> pytest
 ```
 
 ## Версии

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Yougile API models"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -17,6 +17,70 @@ dependencies = [
   "requests",
   "httpx",
 ]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=9",
+  "pytest-asyncio>=1.3",
+  "pytest-cov>=7.1",
+  "pyright>=1.1.408",
+  "ruff>=0.15",
+  "types-requests>=2.33",
+]
+
 [project.urls]
 Homepage = "https://github.com/txello/YouGile"
 Issues = "https://github.com/txello/YouGile/issues"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "--cov=yougile --cov-report=term-missing"
+
+[tool.coverage.run]
+source = ["yougile"]
+
+[tool.coverage.report]
+skip_covered = false
+show_missing = true
+omit = [
+  "yougile/models/*",
+]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+exclude = [
+  ".git",
+  ".venv",
+  "venv",
+  "__pycache__",
+]
+
+[tool.ruff.lint]
+select = [
+  "E",
+  "F",
+  "I",
+  "UP",
+]
+ignore = [
+  "E501",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.pyright]
+include = ["yougile", "tests"]
+exclude = [
+  ".venv",
+  "venv",
+  "__pycache__",
+]
+pythonVersion = "3.10"
+typeCheckingMode = "basic"
+reportMissingImports = "none"
+reportMissingTypeStubs = "none"
+reportMissingModuleSource = "none"

--- a/tests/test_request_clients.py
+++ b/tests/test_request_clients.py
@@ -1,0 +1,478 @@
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import requests
+from pydantic import BaseModel
+
+import yougile
+
+
+class AuthenticatedQueryModel(BaseModel):
+    token: str | None = None
+    chatId: str
+    includeArchived: bool | None = None
+
+    _url = "/api-v2/chats/{chatId}"
+    _method = "get"
+    _url_parse = ("chatId",)
+    _url_params = ("includeArchived",)
+
+
+class PublicQueryModel(BaseModel):
+    companyId: str
+
+    _url = "/api-v2/public/{companyId}"
+    _method = "get"
+    _url_parse = ("companyId",)
+
+
+class UploadModel(BaseModel):
+    token: str | None = None
+    file: Any
+    description: str | None = None
+
+    _url = "/api-v2/files"
+    _method = "post"
+    _file = ("file",)
+
+
+class OptionalUploadModel(BaseModel):
+    token: str | None = None
+    file: Any | None = None
+    description: str | None = None
+
+    _url = "/api-v2/files"
+    _method = "post"
+    _file = ("file",)
+
+
+class FileObjectUploadModel(BaseModel):
+    token: str | None = None
+    file: Any
+    description: str | None = None
+
+    _url = "/api-v2/files"
+    _method = "post"
+    _file = ("file",)
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "file": self.file,
+            "description": self.description,
+        }
+
+
+class ComplexQueryModel(BaseModel):
+    token: str | None = None
+    companyId: str
+    boardId: str
+    limit: int | None = None
+    archived: bool | None = None
+
+    _url = "/api-v2/companies/{companyId}/boards/{boardId}"
+    _method = "get"
+    _url_parse = ("companyId", "boardId")
+    _url_params = ("limit", "archived")
+
+
+def test_query_uses_model_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    model = AuthenticatedQueryModel(
+        token="model-token",
+        chatId="42",
+        includeArchived=True,
+    )
+    response = yougile.query(model)
+
+    assert isinstance(response, requests.Response)
+    assert captured["url"] == "https://ru.yougile.com/api-v2/chats/42?includeArchived=True"
+    assert captured["headers"]["Authorization"] == "Bearer model-token"
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert captured["json"] is None
+
+
+def test_client_token_and_timeout_apply_to_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    client = yougile.Client(
+        token="client-token",
+        base_url="https://example.yougile.local/",
+        timeout=7.5,
+    )
+    model = AuthenticatedQueryModel(chatId="7")
+
+    client.query(model)
+
+    assert captured["url"] == "https://example.yougile.local/api-v2/chats/7"
+    assert captured["headers"]["Authorization"] == "Bearer client-token"
+    assert captured["timeout"] == 7.5
+
+
+def test_query_raises_without_token() -> None:
+    model = AuthenticatedQueryModel(chatId="42")
+
+    with pytest.raises(yougile.MissingTokenError):
+        yougile.query(model)
+
+
+def test_public_query_does_not_require_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    response = yougile.query(PublicQueryModel(companyId="abc"))
+
+    assert isinstance(response, requests.Response)
+    assert captured["url"] == "https://ru.yougile.com/api-v2/public/abc"
+    assert "Authorization" not in captured["headers"]
+
+
+def test_query_uploads_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+    file_path = tmp_path / "report.txt"
+    file_path.write_text("payload", encoding="utf-8")
+
+    def fake_post(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    model = UploadModel(
+        token="upload-token",
+        file=str(file_path),
+        description="Quarterly report",
+    )
+    yougile.query(model)
+
+    assert captured["data"] == {"description": "Quarterly report"}
+    assert captured["files"]["file"][0] == "report.txt"
+    assert captured["headers"]["Authorization"] == "Bearer upload-token"
+    assert "Content-Type" not in captured["headers"]
+
+
+def test_query_token_argument_has_highest_priority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    client = yougile.Client(token="client-token")
+    model = AuthenticatedQueryModel(token="model-token", chatId="314")
+
+    client.query(model, token="call-token")
+
+    assert captured["headers"]["Authorization"] == "Bearer call-token"
+
+
+def test_query_normalizes_base_url_and_skips_none_query_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    model = ComplexQueryModel(
+        token="query-token",
+        companyId="c-1",
+        boardId="b-2",
+        limit=50,
+        archived=None,
+    )
+
+    response = yougile.query(model, base_url="https://custom.yougile.local/")
+
+    assert isinstance(response, requests.Response)
+    assert (
+        captured["url"]
+        == "https://custom.yougile.local/api-v2/companies/c-1/boards/b-2?limit=50"
+    )
+
+
+def test_query_normalizes_base_url_without_trailing_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    model = AuthenticatedQueryModel(token="query-token", chatId="11")
+    yougile.query(model, base_url="https://custom.yougile.local")
+
+    assert captured["url"] == "https://custom.yougile.local/api-v2/chats/11"
+
+
+def test_query_includes_multiple_query_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    model = ComplexQueryModel(
+        token="query-token",
+        companyId="c-1",
+        boardId="b-2",
+        limit=50,
+        archived=False,
+    )
+
+    yougile.query(model)
+
+    assert (
+        captured["url"]
+        == "https://ru.yougile.com/api-v2/companies/c-1/boards/b-2?limit=50&archived=False"
+    )
+
+
+def test_query_does_not_mutate_original_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(**kwargs: Any) -> requests.Response:
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    model = ComplexQueryModel(
+        token="stable-token",
+        companyId="original-company",
+        boardId="original-board",
+        limit=10,
+    )
+
+    yougile.query(model)
+
+    assert model.token == "stable-token"
+    assert model.companyId == "original-company"
+    assert model.boardId == "original-board"
+    assert model.limit == 10
+
+
+def test_query_uploads_bytes_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    model = UploadModel(
+        token="upload-token",
+        file=b"raw-bytes",
+        description="Binary payload",
+    )
+    yougile.query(model)
+
+    assert captured["files"]["file"][0] == "file.bin"
+    assert captured["files"]["file"][1] == b"raw-bytes"
+
+
+def test_query_uploads_file_object(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+    file_path = tmp_path / "file-object.txt"
+    file_path.write_text("payload", encoding="utf-8")
+
+    def fake_post(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    with file_path.open("rb") as file_object:
+        model = FileObjectUploadModel(
+            token="upload-token",
+            file=file_object,
+            description="File object payload",
+        )
+        yougile.query(model)
+
+    assert captured["files"]["file"][0] == "file-object.txt"
+
+
+def test_query_passes_tuple_file_payload_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    file_tuple = ("report.bin", b"tuple-bytes", "application/octet-stream")
+
+    def fake_post(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    model = UploadModel(
+        token="upload-token",
+        file=file_tuple,
+        description="Tuple payload",
+    )
+    yougile.query(model)
+
+    assert captured["files"]["file"] == file_tuple
+
+
+def test_query_with_empty_file_field_sends_multipart_without_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(**kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return requests.Response()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    model = OptionalUploadModel(
+        token="upload-token",
+        file=None,
+        description="No file attached",
+    )
+    yougile.query(model)
+
+    assert captured["data"] == {"description": "No file attached"}
+    assert captured["files"] == {}
+    assert "Content-Type" not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_public_async_client_query_does_not_require_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeAsyncClient:
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def request(self, **kwargs: Any) -> httpx.Response:
+            captured.update(kwargs)
+            return httpx.Response(200)
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    response = await yougile.AsyncClient().query(PublicQueryModel(companyId="public-id"))
+
+    assert response.status_code == 200
+    assert captured["url"] == "https://ru.yougile.com/api-v2/public/public-id"
+    assert "Authorization" not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_query_async_uses_client_token_and_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeAsyncClient:
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def request(self, **kwargs: Any) -> httpx.Response:
+            captured.update(kwargs)
+            return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    client = yougile.AsyncClient(
+        token="async-token",
+        base_url="https://async.yougile.local/",
+        timeout=2.5,
+    )
+    model = AuthenticatedQueryModel(chatId="99")
+
+    response = await client.query(model)
+
+    assert response.status_code == 200
+    assert captured["method"] == "get"
+    assert captured["url"] == "https://async.yougile.local/api-v2/chats/99"
+    assert captured["headers"]["Authorization"] == "Bearer async-token"
+    assert captured["timeout"] == 2.5
+
+
+@pytest.mark.asyncio
+async def test_query_async_raises_without_token() -> None:
+    model = AuthenticatedQueryModel(chatId="100")
+
+    with pytest.raises(yougile.MissingTokenError):
+        await yougile.query_async(model)
+
+
+@pytest.mark.asyncio
+async def test_query_async_uploads_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+    file_path = tmp_path / "async-report.txt"
+    file_path.write_text("payload", encoding="utf-8")
+
+    class FakeAsyncClient:
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def request(self, **kwargs: Any) -> httpx.Response:
+            captured.update(kwargs)
+            return httpx.Response(201)
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    model = UploadModel(
+        token="async-upload-token",
+        file=str(file_path),
+        description="Async quarterly report",
+    )
+    response = await yougile.query_async(model)
+
+    assert response.status_code == 201
+    assert captured["method"] == "post"
+    assert captured["data"] == {"description": "Async quarterly report"}
+    assert captured["files"]["file"][0] == "async-report.txt"
+    assert captured["headers"]["Authorization"] == "Bearer async-upload-token"
+    assert "Content-Type" not in captured["headers"]
+
+
+def test_public_symbols_are_exported() -> None:
+    assert yougile.Client is not None
+    assert yougile.AsyncClient is not None
+    assert yougile.MissingTokenError is not None
+    assert yougile.query is not None
+    assert yougile.query_async is not None

--- a/yougile/__init__.py
+++ b/yougile/__init__.py
@@ -1,6 +1,14 @@
 from pydantic import BaseModel
 
 from .async_request import AsyncClient, query_async
+from .errors import MissingTokenError
 from .request import Client, query
 
-__all__ = ["AsyncClient", "BaseModel", "Client", "query", "query_async"]
+__all__ = [
+    "AsyncClient",
+    "BaseModel",
+    "Client",
+    "MissingTokenError",
+    "query",
+    "query_async",
+]

--- a/yougile/_request_common.py
+++ b/yougile/_request_common.py
@@ -1,0 +1,127 @@
+import os
+from contextlib import ExitStack
+from dataclasses import dataclass
+from io import IOBase
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic import BaseModel
+
+from .errors import MissingTokenError
+
+YOUGILE_URL = "https://ru.yougile.com"
+
+
+@dataclass(slots=True)
+class PreparedRequest:
+    method: str
+    url: str
+    headers: dict[str, str]
+    json_body: dict[str, Any] | None
+    form_body: dict[str, Any] | None
+    file_field_names: tuple[str, ...]
+
+
+def normalize_base_url(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
+def prepare_request(
+    arg: BaseModel,
+    *,
+    fallback_token: str | None,
+) -> PreparedRequest:
+    model = arg.model_copy()
+    url = str(getattr(model, "_url"))
+    method = str(getattr(model, "_method", "get")).lower()
+    headers: dict[str, str] = {}
+
+    request_token = fallback_token
+    if hasattr(model, "token"):
+        model_token = cast(str | None, getattr(model, "token"))
+        if request_token is None:
+            request_token = model_token
+        delattr(model, "token")
+
+        if request_token is None:
+            raise MissingTokenError(
+                "This request requires a token. Pass it in the model, query(...), "
+                "or Client(...)."
+            )
+
+    if request_token is not None:
+        headers["Authorization"] = f"Bearer {request_token}"
+
+    url_parse_names = cast(tuple[str, ...], tuple(getattr(model, "_url_parse", ())))
+    if url_parse_names:
+        url = url.format(**{name: getattr(model, name) for name in url_parse_names})
+
+    for name in url_parse_names:
+        delattr(model, name)
+
+    params_parts: list[str] = []
+    for name in cast(tuple[str, ...], tuple(getattr(model, "_url_params", ()))):
+        value = getattr(model, name)
+        if value is not None:
+            params_parts.append(f"{name}={value}")
+        delattr(model, name)
+    if params_parts:
+        url = f"{url}?{'&'.join(params_parts)}"
+
+    body = cast(dict[str, Any], model.model_dump(exclude_none=True))
+    file_field_names = cast(tuple[str, ...], tuple(getattr(model, "_file", ())))
+
+    if file_field_names:
+        return PreparedRequest(
+            method=method,
+            url=url,
+            headers=headers,
+            json_body=None,
+            form_body=body,
+            file_field_names=file_field_names,
+        )
+
+    headers["Content-Type"] = "application/json"
+    return PreparedRequest(
+        method=method,
+        url=url,
+        headers=headers,
+        json_body=body or None,
+        form_body=None,
+        file_field_names=file_field_names,
+    )
+
+
+def build_multipart_files(
+    body: dict[str, Any],
+    file_field_names: tuple[str, ...],
+    stack: ExitStack,
+) -> dict[str, Any]:
+    files: dict[str, Any] = {}
+    for field_name in file_field_names:
+        value = body.pop(field_name, None)
+        if value is None:
+            continue
+
+        if (
+            isinstance(value, tuple)
+            and 2 <= len(value) <= 3
+            and isinstance(value[0], str)
+        ):
+            files[field_name] = value
+            continue
+
+        if isinstance(value, (bytes, bytearray)):
+            files[field_name] = (f"{field_name}.bin", bytes(value))
+            continue
+
+        if isinstance(value, IOBase):
+            name = getattr(value, "name", f"{field_name}.bin")
+            files[field_name] = (os.path.basename(str(name)), value)
+            continue
+
+        path = Path(str(value))
+        file_object = stack.enter_context(open(path, "rb"))
+        files[field_name] = (path.name, file_object)
+
+    return files

--- a/yougile/async_request.py
+++ b/yougile/async_request.py
@@ -1,111 +1,60 @@
 from contextlib import ExitStack
-from io import IOBase
-import os
-from pathlib import Path
-from typing import Any
 
 import httpx
 from pydantic import BaseModel
 
-
-YOUGILE_URL = "https://ru.yougile.com"
-
-
-def _normalize_base_url(base_url: str) -> str:
-    return base_url.rstrip("/")
+from ._request_common import (
+    YOUGILE_URL,
+    build_multipart_files,
+    normalize_base_url,
+    prepare_request,
+)
 
 
 class AsyncClient:
     """Асинхронный клиент YouGile API с настройками подключения."""
 
-    def __init__(self, token: str | None = None, base_url: str = YOUGILE_URL) -> None:
+    def __init__(
+        self,
+        token: str | None = None,
+        base_url: str = YOUGILE_URL,
+        timeout: float | None = None,
+    ) -> None:
         self.token = token
-        self.base_url = _normalize_base_url(base_url)
+        self.base_url = normalize_base_url(base_url)
+        self.timeout = timeout
 
-    async def query(self, arg: BaseModel, token: str | None = None) -> httpx.Response:
-        """
-        Универсальный запрос:
-        - если модель содержит _file (имена полей-файлов) -> multipart/form-data
-        - иначе -> JSON
-        Поддерживаются варианты значений файлового поля:
-          bytes | путь (str/Path) | файловый объект (IOBase) | ('name', bytes[, 'mime/type'])
-        """
-        arg = arg.model_copy()
-        url: str = getattr(arg, "_url")
-        method: str = getattr(arg, "_method", "get").lower()
+    async def query(
+        self,
+        arg: BaseModel,
+        token: str | None = None,
+    ) -> httpx.Response:
+        prepared = prepare_request(
+            arg,
+            fallback_token=token or self.token,
+        )
 
-        headers: dict[str, str] = {}
-        request_token = token or self.token
-
-        if hasattr(arg, "token"):
-            model_token = getattr(arg, "token")
-            if request_token is None:
-                request_token = model_token
-            if request_token is not None:
-                headers["Authorization"] = f"Bearer {request_token}"
-            delattr(arg, "token")
-
-        for name in getattr(arg, "_url_parse", ()):
-            url = url.format(**{name: getattr(arg, name)})
-            delattr(arg, name)
-
-        params_parts: list[str] = []
-        for name in getattr(arg, "_url_params", ()):
-            value = getattr(arg, name)
-            if value is not None:
-                params_parts.append(f"{name}={value}")
-            delattr(arg, name)
-        if params_parts:
-            url = f"{url}?{'&'.join(params_parts)}"
-
-        body: dict[str, Any] = arg.model_dump(exclude_none=True)
-        file_field_names = tuple(getattr(arg, "_file", ()))
-
-        if file_field_names:
+        if prepared.file_field_names:
             with ExitStack() as stack:
-                files: dict[str, Any] = {}
-                for fname in file_field_names:
-                    value = body.pop(fname, None)
-                    if value is None:
-                        continue
-
-                    if (
-                        isinstance(value, tuple)
-                        and 2 <= len(value) <= 3
-                        and isinstance(value[0], str)
-                    ):
-                        files[fname] = value
-                        continue
-
-                    if isinstance(value, (bytes, bytearray)):
-                        files[fname] = (f"{fname}.bin", bytes(value))
-                        continue
-
-                    if isinstance(value, IOBase):
-                        name = getattr(value, "name", f"{fname}.bin")
-                        files[fname] = (os.path.basename(str(name)), value)
-                        continue
-
-                    path = Path(str(value))
-                    file_object = stack.enter_context(open(path, "rb"))
-                    files[fname] = (path.name, file_object)
-
+                form_body = dict(prepared.form_body or {})
+                files = build_multipart_files(form_body, prepared.file_field_names, stack)
                 async with httpx.AsyncClient() as client:
                     return await client.request(
-                        method=method,
-                        url=self.base_url + url,
-                        headers=headers,
-                        data=body or None,
+                        method=prepared.method,
+                        url=self.base_url + prepared.url,
+                        headers=prepared.headers,
+                        data=form_body or None,
                         files=files,
+                        timeout=self.timeout,
                     )
 
-        headers["Content-Type"] = "application/json"
         async with httpx.AsyncClient() as client:
             return await client.request(
-                method=method,
-                url=self.base_url + url,
-                headers=headers,
-                json=body or None,
+                method=prepared.method,
+                url=self.base_url + prepared.url,
+                headers=prepared.headers,
+                json=prepared.json_body,
+                timeout=self.timeout,
             )
 
 

--- a/yougile/errors.py
+++ b/yougile/errors.py
@@ -1,0 +1,2 @@
+class MissingTokenError(ValueError):
+    """Raised when an authenticated API request is sent without a token."""

--- a/yougile/models/__init__.py
+++ b/yougile/models/__init__.py
@@ -1,101 +1,100 @@
 from .auth import (
     AuthKeyController_companiesList,
-    getCompanies,
-    AuthKeyController_search,
     AuthKeyController_create,
     AuthKeyController_delete,
+    AuthKeyController_search,
+    getCompanies,
 )
 from .boards import (
-    BoardController_search,
-    BoardController_get,
     BoardController_create,
+    BoardController_get,
+    BoardController_search,
     BoardController_update,
 )
 from .chatmessages import (
-    ChatMessageController_search,
     ChatMessageController_get,
+    ChatMessageController_search,
     ChatMessageController_sendMessage,
     ChatMessageController_update,
 )
 from .columns import (
-    ColumnController_search,
-    ColumnController_get,
     ColumnController_create,
+    ColumnController_get,
+    ColumnController_search,
     ColumnController_update,
 )
-
+from .companies import CompanyController_get, CompanyController_update
+from .crm import CrmContactPersonsController_create
+from .crmids import CrmExternalIdController_findContactByExternalId
 from .departments import (
-    DepartmentController_search,
-    DepartmentController_get,
     DepartmentController_create,
+    DepartmentController_get,
+    DepartmentController_search,
     DepartmentController_update,
 )
 from .employees import (
-    UserController_search,
-    UserController_get,
     UserController_create,
-    UserController_update,
     UserController_delete,
+    UserController_get,
+    UserController_search,
+    UserController_update,
 )
+from .files import FileController_uploadFile
 from .groupchats import (
-    GroupChatController_search,
-    GroupChatController_get,
     GroupChatController_create,
+    GroupChatController_get,
+    GroupChatController_search,
     GroupChatController_update,
 )
 from .projectroles import (
-    ProjectRolesController_search,
-    ProjectRolesController_get,
     ProjectRolesController_create,
-    ProjectRolesController_update,
     ProjectRolesController_delete,
+    ProjectRolesController_get,
+    ProjectRolesController_search,
+    ProjectRolesController_update,
 )
 from .projects import (
-    ProjectController_search,
-    ProjectController_get,
     ProjectController_create,
+    ProjectController_get,
+    ProjectController_search,
     ProjectController_update,
 )
 from .sprintsticker import (
-    SprintStickerController_search,
-    SprintStickerController_getSticker,
     SprintStickerController_create,
+    SprintStickerController_getSticker,
+    SprintStickerController_search,
     SprintStickerController_update,
 )
 from .sprintstickerstate import (
-    SprintStickerStateController_get,
     SprintStickerStateController_create,
+    SprintStickerStateController_get,
     SprintStickerStateController_update,
 )
 from .stringsticker import (
-    StringStickerController_search,
-    StringStickerController_get,
     StringStickerController_create,
+    StringStickerController_get,
+    StringStickerController_search,
     StringStickerController_update,
 )
 from .stringstickerstate import (
-    StringStickerStateController_get,
     StringStickerStateController_create,
+    StringStickerStateController_get,
     StringStickerStateController_update,
 )
 from .tasks import (
-    TaskController_search,
-    TaskController_searchReversed,
+    TaskController_create,
     TaskController_get,
     TaskController_getChatSubscribers,
-    TaskController_create,
+    TaskController_search,
+    TaskController_searchReversed,
     TaskController_update,
     TaskController_updateChatSubscribers,
 )
 from .webhooks import (
-    WebhookController_search,
     WebhookController_create,
     WebhookController_put,
+    WebhookController_search,
 )
-from .companies import CompanyController_get, CompanyController_update
-from .files import FileController_uploadFile
-from .crm import CrmContactPersonsController_create
-from .crmids import CrmExternalIdController_findContactByExternalId
 
 __all__ = [
     "AuthKeyController_companiesList",

--- a/yougile/request.py
+++ b/yougile/request.py
@@ -1,107 +1,56 @@
 from contextlib import ExitStack
-from io import IOBase
-import os
-from pathlib import Path
-from typing import Any
 
 import requests
 from pydantic import BaseModel
 
-
-YOUGILE_URL = "https://ru.yougile.com"
-
-
-def _normalize_base_url(base_url: str) -> str:
-    return base_url.rstrip("/")
+from ._request_common import (
+    YOUGILE_URL,
+    build_multipart_files,
+    normalize_base_url,
+    prepare_request,
+)
 
 
 class Client:
     """Клиент YouGile API с настройками подключения."""
 
-    def __init__(self, token: str | None = None, base_url: str = YOUGILE_URL) -> None:
+    def __init__(
+        self,
+        token: str | None = None,
+        base_url: str = YOUGILE_URL,
+        timeout: float | None = None,
+    ) -> None:
         self.token = token
-        self.base_url = _normalize_base_url(base_url)
+        self.base_url = normalize_base_url(base_url)
+        self.timeout = timeout
 
-    def query(self, arg: BaseModel, token: str | None = None) -> requests.Response:
-        """
-        Универсальный запрос:
-        - если модель содержит _file (имена полей-файлов) -> multipart/form-data
-        - иначе -> JSON
-        Поддерживаются варианты значений файлового поля:
-          bytes | путь (str/Path) | файловый объект (IOBase) | ('name', bytes[, 'mime/type'])
-        """
-        arg = arg.model_copy()
-        url: str = getattr(arg, "_url")
-        method: str = getattr(arg, "_method", "get").lower()
+    def query(
+        self,
+        arg: BaseModel,
+        token: str | None = None,
+    ) -> requests.Response:
+        prepared = prepare_request(
+            arg,
+            fallback_token=token or self.token,
+        )
 
-        headers: dict[str, str] = {}
-        request_token = token or self.token
-
-        if hasattr(arg, "token"):
-            model_token = getattr(arg, "token")
-            if request_token is None:
-                request_token = model_token
-            if request_token is not None:
-                headers["Authorization"] = f"Bearer {request_token}"
-            delattr(arg, "token")
-
-        for name in getattr(arg, "_url_parse", ()):
-            url = url.format(**{name: getattr(arg, name)})
-            delattr(arg, name)
-
-        params_parts: list[str] = []
-        for name in getattr(arg, "_url_params", ()):
-            value = getattr(arg, name)
-            if value is not None:
-                params_parts.append(f"{name}={value}")
-            delattr(arg, name)
-        if params_parts:
-            url = f"{url}?{'&'.join(params_parts)}"
-
-        body: dict[str, Any] = arg.model_dump(exclude_none=True)
-        file_field_names = tuple(getattr(arg, "_file", ()))
-
-        if file_field_names:
+        if prepared.file_field_names:
             with ExitStack() as stack:
-                files: dict[str, Any] = {}
-                for fname in file_field_names:
-                    value = body.pop(fname, None)
-                    if value is None:
-                        continue
-
-                    if (
-                        isinstance(value, tuple)
-                        and 2 <= len(value) <= 3
-                        and isinstance(value[0], str)
-                    ):
-                        files[fname] = value
-                        continue
-
-                    if isinstance(value, (bytes, bytearray)):
-                        files[fname] = (f"{fname}.bin", bytes(value))
-                        continue
-
-                    if isinstance(value, IOBase):
-                        name = getattr(value, "name", f"{fname}.bin")
-                        files[fname] = (os.path.basename(str(name)), value)
-                        continue
-
-                    path = Path(str(value))
-                    file_object = stack.enter_context(open(path, "rb"))
-                    files[fname] = (path.name, file_object)
-
-                return getattr(requests, method)(
-                    url=self.base_url + url,
-                    headers=headers,
-                    data=body or None,
+                form_body = dict(prepared.form_body or {})
+                files = build_multipart_files(form_body, prepared.file_field_names, stack)
+                return getattr(requests, prepared.method)(
+                    url=self.base_url + prepared.url,
+                    headers=prepared.headers,
+                    data=form_body or None,
                     files=files,
+                    timeout=self.timeout,
                 )
 
-        headers["Content-Type"] = "application/json"
-        return getattr(requests, method)(
-            url=self.base_url + url,
-            headers=headers,
-            json=body or None,
+        return getattr(requests, prepared.method)(
+            url=self.base_url + prepared.url,
+            headers=prepared.headers,
+            json=prepared.json_body,
+            timeout=self.timeout,
         )
 
 


### PR DESCRIPTION
## Что сделано

В этом PR улучшена инфраструктура качества и упрощена/усилена логика request-слоя библиотеки.

### Основные изменения

- поднята минимальная версия Python до `3.10`
- добавлены и настроены `ruff`, `pyright`, `pytest`, `pytest-cov`
- добавлен quality workflow для GitHub Actions
- общая логика подготовки запросов вынесена в отдельный helper
- добавлена явная ошибка `MissingTokenError`, если запрос требует токен, но он не передан
- добавлена поддержка `timeout` на уровне `Client` и `AsyncClient`
- улучшена документация по локальной разработке и проверкам
- добавлен набор sync/async тестов для request-слоя

### Тесты

Локально проверено:
- `ruff check .`
- `pyright`
- `pytest`

Результат:
- `19 passed`
- coverage `100%` по включенным исполняемым файлам request-слоя
